### PR TITLE
New Add `es/no-function-bind` rule

### DIFF
--- a/docs/rules/no-function-bind.md
+++ b/docs/rules/no-function-bind.md
@@ -1,0 +1,43 @@
+# disallow `Function.prototype.bind()` call (es/no-function-bind)
+
+This rule reports ES5 `Function.prototype.bind()` call as errors (to the extent possible).
+
+## Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+```js
+var fn = function() {}.bind(this)
+
+var res = function() {
+    var data = x + y
+    return this.proc(data)
+}.bind(this)()
+
+button.addEventListener('click', function() { this.onClick() }.bind(this))
+```
+
+👌 Examples of **correct** code for this rule:
+
+```js
+var fn = function() {}
+
+var that = this
+var res = (function() {
+    var data = x + y
+    return that.proc(data)
+})()
+
+button.addEventListener('click', function() { that.onClick() })
+```
+
+```js
+var fn = _.bind(function() {}, this)
+
+var res = _.bind(function() {
+    var data = x + y
+    return this.proc(data)
+}, this)()
+
+button.addEventListener('click', _.bind(function() { this.onClick() }, this))
+```

--- a/lib/rules/no-function-bind.js
+++ b/lib/rules/no-function-bind.js
@@ -1,0 +1,199 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/
+
+/**
+ * Check if property name equals.
+ * @param  {ASTNode} node MemberExpression node
+ * @param  {string} name property name
+ * @returns {boolean} equal
+ */
+function propertyNameEquals(node, name) {
+    if (!node.computed) {
+        if (
+            node.property.type !== "Identifier" ||
+            node.property.name !== name
+        ) {
+            return false
+        }
+    } else if (
+        node.property.type !== "Literal" ||
+        node.property.value !== name
+    ) {
+        return false
+    }
+    return true
+}
+
+/**
+ * Checks whether a given node is a function node or not.
+ * The following types are function nodes:
+ *
+ * - ArrowFunctionExpression
+ * - FunctionDeclaration
+ * - FunctionExpression
+ *
+ * @param {ASTNode|null} node - A node to check.
+ * @returns {boolean} `true` if the node is a function node.
+ */
+function isFunction(node) {
+    return Boolean(node && anyFunctionPattern.test(node.type))
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow `Function.prototype.bind()` call.",
+            category: "ES5",
+            recommended: false,
+            url:
+                "https://github.com/mysticatea/eslint-plugin-es/blob/v1.1.0/docs/rules/no-function-bind.md",
+        },
+        fixable: null,
+        schema: [],
+        messages: {
+            forbidden: "ES5 `Function.prototype.bind()` call are forbidden.",
+        },
+    },
+    create(context) {
+        const functionVariables = []
+
+        /**
+         * Check whether it is a reference initialized with Function
+         * @param  {Variable} variable target Variable
+         * @param  {Reference} targetReference target Reference
+         * @param  {Array} [checked] Array of checked Nodes
+         * @returns {boolean} Is a function writed
+         */
+        function isFunctionReference(variable, targetReference, checked) {
+            const targetIndex = variable.references.indexOf(targetReference)
+            const targetScope = targetReference.from
+
+            let scopeLastWriteExpr = undefined
+            const otherScopeWriteExprs = []
+            variable.references.forEach((reference, index) => {
+                const writeExpr = reference.writeExpr
+                if (!writeExpr || reference.partial) {
+                    return
+                }
+                const selfAssignment = variable.references.some(
+                    ref => writeExpr === ref.identifier
+                )
+                if (selfAssignment) {
+                    return
+                }
+                if (targetScope === reference.from) {
+                    // scope
+                    if (index < targetIndex) {
+                        scopeLastWriteExpr = writeExpr
+                    }
+                } else {
+                    // other scope
+                    otherScopeWriteExprs.push(writeExpr)
+                }
+            })
+            if (
+                !otherScopeWriteExprs.every(
+                    writeExpr =>
+                        isFunction(writeExpr) ||
+                        isFunctionVariable(writeExpr, checked)
+                )
+            ) {
+                // has not function
+                return false
+            }
+            if (scopeLastWriteExpr) {
+                return (
+                    isFunction(scopeLastWriteExpr) ||
+                    isFunctionVariable(scopeLastWriteExpr, checked)
+                )
+            }
+            return variable.defs.every(
+                def =>
+                    isFunction(def.node) ||
+                    isFunctionVariable(def.node, checked)
+            )
+        }
+
+        /**
+         * Find reference
+         * @param  {ASTNode} node target identifier Node
+         * @returns {object} reference info
+         */
+        function findReference(node) {
+            for (const variable of functionVariables) {
+                for (const reference of variable.references) {
+                    if (reference.identifier === node) {
+                        return {
+                            variable,
+                            reference,
+                        }
+                    }
+                }
+            }
+            return null
+        }
+
+        /**
+         * Check whether it is a variable initialized with Function
+         * @param  {ASTNode} node identifier Node
+         * @param  {Array} [optChecked] Array of checked Nodes
+         * @returns {boolean} variable is a function
+         */
+        function isFunctionVariable(node, optChecked) {
+            if (node.type !== "Identifier") {
+                return false
+            }
+            const checked = optChecked || []
+            if (checked.indexOf(node) >= 0) {
+                return false
+            }
+            checked.push(node)
+            const ref = findReference(node)
+            if (!ref) {
+                return false
+            }
+            const { variable, reference } = ref
+            return isFunctionReference(variable, reference, checked)
+        }
+
+        return {
+            "VariableDeclarator, VariableDeclaration, FunctionDeclaration, FunctionExpression, ArrowFunctionExpression, ClassDeclaration, ClassExpression, CatchClause, ImportDeclaration, ImportSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier"(
+                node
+            ) {
+                const declaredVariables = context.getDeclaredVariables(node)
+                functionVariables.push(...declaredVariables)
+            },
+            CallExpression(node) {
+                const callee = node.callee
+                if (callee.type !== "MemberExpression") {
+                    // not bind
+                    return
+                }
+
+                if (!propertyNameEquals(callee, "bind")) {
+                    // not bind
+                    return
+                }
+
+                const object = callee.object
+                if (isFunction(object)) {
+                    context.report({ node, messageId: "forbidden" })
+                } else if (
+                    object.type === "MemberExpression" &&
+                    propertyNameEquals(object, "prototype") &&
+                    object.object.type === "Identifier" &&
+                    object.object.name === "Function"
+                ) {
+                    context.report({ node, messageId: "forbidden" })
+                } else if (isFunctionVariable(object)) {
+                    context.report({ node, messageId: "forbidden" })
+                }
+            },
+        }
+    },
+}

--- a/lib/rules/no-function-bind.js
+++ b/lib/rules/no-function-bind.js
@@ -7,26 +7,17 @@
 const anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/
 
 /**
- * Check if property name equals.
+ * Get property name.
  * @param  {ASTNode} node MemberExpression node
- * @param  {string} name property name
- * @returns {boolean} equal
+ * @returns {string} name
  */
-function propertyNameEquals(node, name) {
+function getPropertyName(node) {
     if (!node.computed) {
-        if (
-            node.property.type !== "Identifier" ||
-            node.property.name !== name
-        ) {
-            return false
-        }
-    } else if (
-        node.property.type !== "Literal" ||
-        node.property.value !== name
-    ) {
-        return false
+        return node.property.name
+    } else if (node.property.type === "Literal") {
+        return node.property.value
     }
-    return true
+    return null
 }
 
 /**
@@ -161,6 +152,23 @@ module.exports = {
             return isFunctionReference(variable, reference, checked)
         }
 
+        /**
+         * Get method target Node
+         * @param  {ASTNode} node CallExpression node
+         * @returns {ASTNode} method target Node
+         */
+        function getMethodTarget(node) {
+            const callee = node.callee
+            if (callee.type !== "MemberExpression") {
+                return callee
+            }
+            const methodName = getPropertyName(callee)
+            if (methodName === "call" || methodName === "apply") {
+                return callee.object
+            }
+            return callee
+        }
+
         return {
             "VariableDeclarator, VariableDeclaration, FunctionDeclaration, FunctionExpression, ArrowFunctionExpression, ClassDeclaration, ClassExpression, CatchClause, ImportDeclaration, ImportSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier"(
                 node
@@ -169,13 +177,13 @@ module.exports = {
                 functionVariables.push(...declaredVariables)
             },
             CallExpression(node) {
-                const callee = node.callee
+                const callee = getMethodTarget(node)
                 if (callee.type !== "MemberExpression") {
                     // not bind
                     return
                 }
 
-                if (!propertyNameEquals(callee, "bind")) {
+                if (getPropertyName(callee) !== "bind") {
                     // not bind
                     return
                 }
@@ -185,7 +193,7 @@ module.exports = {
                     context.report({ node, messageId: "forbidden" })
                 } else if (
                     object.type === "MemberExpression" &&
-                    propertyNameEquals(object, "prototype") &&
+                    getPropertyName(object) === "prototype" &&
                     object.object.type === "Identifier" &&
                     object.object.name === "Function"
                 ) {

--- a/tests/lib/rules/no-function-bind.js
+++ b/tests/lib/rules/no-function-bind.js
@@ -1,0 +1,212 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-function-bind.js")
+
+new RuleTester().run("no-function-bind", rule, {
+    valid: [
+        `
+var fn = function() {}
+
+var that = this
+var res = (function() {
+    var data = x + y
+    return that.proc(data)
+})()
+
+button.addEventListener('click', function() { that.onClick() })
+        `,
+        `
+var fn = _.bind(function() {}, this)
+
+var res = _.bind(function() {
+    var data = x + y
+    return this.proc(data)
+}, this)()
+
+button.addEventListener('click', _.bind(function() { this.onClick() }, this))
+        `,
+        "var fn = function() {}",
+        "var fn = (function() {})",
+        "var res = function() {}.call(this)",
+        "data.bind(this)",
+        "var hasBind = !!function() {}.bind",
+        "var res = (function() { return bindable })().bind(this)",
+        "var fn = function() {}[bind](this)",
+        "String.prototype.bind(function() {}, this)",
+        "var bind = Function.prototype.bind",
+        `
+var fn = unknown
+fn.bind(this)
+        `,
+        `
+var fn = function() {}
+fn = unknown
+fn.bind(this)
+        `,
+        `
+var fn = function() {
+    fn = unknown
+}
+fn.bind(this)
+        `,
+        `
+var fn
+fn.bind(this)
+        `,
+        `
+var {fn} = function() {}
+fn.bind(this)
+        `,
+        `
+var fn = function() {}
+fn = fn.fn
+fn.bind(this)
+        `,
+        `
+function fn() {
+}
+fn = unknown
+fn.bind(this)
+        `,
+        `
+var fn1 = () => {}
+var fn2 = fn1
+function fn3() {
+    fn1 = fn2
+    fn2 = fn1
+}
+fn2.bind(this)
+        `,
+        `
+var fn = unknown
+fn.bind(this)
+fn = () => {}
+        `,
+    ],
+    invalid: [
+        {
+            code: `
+var fn = function() {}.bind(this)
+
+var res = function() {
+    var data = x + y
+    return this.proc(data)
+}.bind(this)()
+
+button.addEventListener('click', function() { this.onClick() }.bind(this))
+            `,
+            errors: [
+                "ES5 `Function.prototype.bind()` call are forbidden.",
+                "ES5 `Function.prototype.bind()` call are forbidden.",
+                "ES5 `Function.prototype.bind()` call are forbidden.",
+            ],
+        },
+        {
+            code: "var fn = function() {}.bind(this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = (function() {}).bind(this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = (((function() {}))).bind(this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = function() {}.bind(me)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = function() {}.bind(this)()",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = function() {}['bind'](this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = Function.prototype.bind(function() {}, this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn = function() {}
+fn.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn1 = function() {}
+var fn2 = fn1
+fn2.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+const fn1 = function() {};
+(function() {
+    const fn1 = unknown
+})()
+fn1.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn = function() {}
+fn = fn
+fn.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn = function() {}
+fn = function() {}
+fn.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn1 = function() {}
+var fn2 = fn1
+fn2 = function() {}
+fn2 = fn1
+fn2.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn = () => {}
+fn.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+function fn() {
+}
+fn.bind(this)
+            `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: `
+var fn = unknown
+fn = function() {}
+fn.bind(this)
+        `,
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-function-bind.js
+++ b/tests/lib/rules/no-function-bind.js
@@ -37,7 +37,7 @@ button.addEventListener('click', _.bind(function() { this.onClick() }, this))
         "var hasBind = !!function() {}.bind",
         "var res = (function() { return bindable })().bind(this)",
         "var fn = function() {}[bind](this)",
-        "String.prototype.bind(function() {}, this)",
+        "String.prototype.bind.call(function() {}, this)",
         "var bind = Function.prototype.bind",
         `
 var fn = unknown
@@ -132,6 +132,14 @@ button.addEventListener('click', function() { this.onClick() }.bind(this))
         },
         {
             code: "var fn = Function.prototype.bind(function() {}, this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = Function.prototype.bind.call(function() {}, this)",
+            errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
+        },
+        {
+            code: "var fn = Function.prototype.bind.apply(function() {}, this)",
             errors: ["ES5 `Function.prototype.bind()` call are forbidden."],
         },
         {


### PR DESCRIPTION
This rule reports ES5 `Function.prototype.bind()` call as errors (to the extent possible).