### PR TITLE
[Update] Make `es/no-arrow-functions` fixable

### DIFF
--- a/docs/rules/no-arrow-functions.md
+++ b/docs/rules/no-arrow-functions.md
@@ -2,6 +2,8 @@
 
 This rule reports ES2015 arrow functions as errors.
 
+- :wrench: The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
 ## Examples
 
 ⛔ Examples of **incorrect** code for this rule:
@@ -9,4 +11,11 @@ This rule reports ES2015 arrow functions as errors.
 ```js
 let a = () => 100
 let b = () => { doSomething() }
+```
+
+👌 Examples of **correct** code for this rule:
+
+```js
+let a = function() { return 100 }
+let b = function() { doSomething() }
 ```

--- a/lib/rules/no-arrow-functions.js
+++ b/lib/rules/no-arrow-functions.js
@@ -13,16 +13,61 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-es/blob/v1.1.0/docs/rules/no-arrow-functions.md",
         },
-        fixable: null,
+        fixable: "code",
         schema: [],
         messages: {
             forbidden: "ES2015 arrow function expressions are forbidden.",
         },
     },
     create(context) {
+        const sourceCode = context.getSourceCode()
+
+        /**
+         * ArrowFunctionExpression to FunctionExpression
+         * @param  {Node} node ArrowFunctionExpression Node
+         * @returns {string} function expression text
+         */
+        function toFunctionExpression(node) {
+            const params = node.params
+            const paramText = params.length
+                ? sourceCode.text.slice(
+                      params[0].range[0],
+                      params[params.length - 1].range[1]
+                  )
+                : ""
+
+            const arrowToken = sourceCode.getTokenBefore(
+                node.body,
+                token => token.type === "Punctuator" && token.value === "=>"
+            )
+
+            const bodyText = sourceCode.text.slice(
+                arrowToken.range[1],
+                node.range[1]
+            )
+            if (node.body.type === "BlockStatement") {
+                return `function(${paramText})${bodyText}`
+            }
+            return `function(${paramText}){return ${bodyText}}`
+        }
+
         return {
             ArrowFunctionExpression(node) {
-                context.report({ node, messageId: "forbidden" })
+                context.report({
+                    node,
+                    messageId: "forbidden",
+                    fix(fixer) {
+                        const code = sourceCode.getText(node)
+                        const hasThis = /this/.test(code)
+                        const functionText = toFunctionExpression(node)
+                        return fixer.replaceText(
+                            node,
+                            hasThis
+                                ? `${functionText}.bind(this)`
+                                : functionText
+                        )
+                    },
+                })
             },
         }
     },

--- a/lib/rules/no-arrow-functions.js
+++ b/lib/rules/no-arrow-functions.js
@@ -51,23 +51,51 @@ module.exports = {
             return `function(${paramText}){return ${bodyText}}`
         }
 
+        /**
+         * Report that ArrowFunctionExpression is being used
+         * @param {Node} node ArrowFunctionExpression Node
+         * @param {boolean} hasThis Whether `this` is referenced in` function` scope
+         * @param {boolean} hasSuper Whether `super` is referenced in` function` scope
+         * @returns {void}
+         */
+        function report(node, hasThis, hasSuper) {
+            context.report({
+                node,
+                messageId: "forbidden",
+                fix(fixer) {
+                    if (hasSuper) {
+                        return undefined
+                    }
+                    const functionText = toFunctionExpression(node)
+                    return fixer.replaceText(
+                        node,
+                        hasThis ? `${functionText}.bind(this)` : functionText
+                    )
+                },
+            })
+        }
+
+        let stack = { upper: null, hasThis: false, hasSuper: false }
         return {
-            ArrowFunctionExpression(node) {
-                context.report({
-                    node,
-                    messageId: "forbidden",
-                    fix(fixer) {
-                        const code = sourceCode.getText(node)
-                        const hasThis = /this/.test(code)
-                        const functionText = toFunctionExpression(node)
-                        return fixer.replaceText(
-                            node,
-                            hasThis
-                                ? `${functionText}.bind(this)`
-                                : functionText
-                        )
-                    },
-                })
+            ":function"() {
+                stack = { upper: stack, hasThis: false, hasSuper: false }
+            },
+            ":function:exit"(node) {
+                const { hasThis, hasSuper } = stack
+                stack = stack.upper
+
+                if (node.type === "ArrowFunctionExpression") {
+                    report(node, hasThis, hasSuper)
+
+                    stack.hasThis = stack.hasThis || hasThis
+                    stack.hasSuper = stack.hasSuper || hasSuper
+                }
+            },
+            ThisExpression() {
+                stack.hasThis = true
+            },
+            Super() {
+                stack.hasSuper = true
             },
         }
     },

--- a/tests/lib/rules/no-arrow-functions.js
+++ b/tests/lib/rules/no-arrow-functions.js
@@ -12,11 +12,103 @@ new RuleTester().run("no-arrow-functions", rule, {
     invalid: [
         {
             code: "() => 1",
+            output: "function(){return  1}",
             errors: ["ES2015 arrow function expressions are forbidden."],
         },
         {
             code: "() => {}",
+            output: "function() {}",
             errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: "() => this.data",
+            output: "function(){return  this.data}.bind(this)",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: "a => a",
+            output: "function(a){return  a}",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: "(a,  b) => a - b",
+            output: "function(a,  b){return  a - b}",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code:
+                "var fnRestParams = (param1, param2, ...rest) => { statements }",
+            output:
+                "var fnRestParams = function(param1, param2, ...rest) { statements }",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code:
+                "var fnDefParams = (param1 = defaultValue1, param2, paramN = defaultValueN) => { statements }",
+            output:
+                "var fnDefParams = function(param1 = defaultValue1, param2, paramN = defaultValueN) { statements }",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code:
+                "var fnDestructuring = ([a, b] = [1, 2], {x: c} = {x: a + b}) => a + b + c;",
+            output:
+                "var fnDestructuring = function([a, b] = [1, 2], {x: c} = {x: a + b}){return  a + b + c};",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: "let square = n => ({ square: n * n });",
+            output: "let square = function(n){return  ({ square: n * n })};",
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: `
+var comment1 = a => /*comment*/ a;
+var comment2 = a => /*
+comment
+*/ a;
+var comment3 = a => // comment
+a;
+            `,
+            output: `
+var comment1 = function(a){return  /*comment*/ a};
+var comment2 = function(a){return  /*
+comment
+*/ a};
+var comment3 = function(a){return  // comment
+a};
+            `,
+            errors: [
+                "ES2015 arrow function expressions are forbidden.",
+                "ES2015 arrow function expressions are forbidden.",
+                "ES2015 arrow function expressions are forbidden.",
+            ],
+        },
+        {
+            code: `
+var fnHasThis1 = () => {
+    proc();
+    return function() {}.bind(this);
+}
+var fnHasThis2 = () => {
+    proc();
+    this.proc()
+}
+            `,
+            output: `
+var fnHasThis1 = function() {
+    proc();
+    return function() {}.bind(this);
+}.bind(this)
+var fnHasThis2 = function() {
+    proc();
+    this.proc()
+}.bind(this)
+            `,
+            errors: [
+                "ES2015 arrow function expressions are forbidden.",
+                "ES2015 arrow function expressions are forbidden.",
+            ],
         },
     ],
 })

--- a/tests/lib/rules/no-arrow-functions.js
+++ b/tests/lib/rules/no-arrow-functions.js
@@ -110,5 +110,21 @@ var fnHasThis2 = function() {
                 "ES2015 arrow function expressions are forbidden.",
             ],
         },
+
+        {
+            code: `
+class SubClass extends SuperClass {
+
+    methodSub() {
+        const f = () => {
+            return super.methodSuper()
+        }
+        return f
+    }
+}
+            `,
+            output: null,
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
     ],
 })

--- a/tests/lib/rules/no-arrow-functions.js
+++ b/tests/lib/rules/no-arrow-functions.js
@@ -110,7 +110,6 @@ var fnHasThis2 = function() {
                 "ES2015 arrow function expressions are forbidden.",
             ],
         },
-
         {
             code: `
 class SubClass extends SuperClass {
@@ -125,6 +124,43 @@ class SubClass extends SuperClass {
             `,
             output: null,
             errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: `
+const f = () => {
+    return function () {
+        return this
+    }
+}
+            `,
+            output: `
+const f = function() {
+    return function () {
+        return this
+    }
+}
+            `,
+            errors: ["ES2015 arrow function expressions are forbidden."],
+        },
+        {
+            code: `
+const f = () => {
+    return () => {
+        return this
+    }
+}
+            `,
+            output: `
+const f = function() {
+    return () => {
+        return this
+    }
+}.bind(this)
+            `,
+            errors: [
+                "ES2015 arrow function expressions are forbidden.",
+                "ES2015 arrow function expressions are forbidden.",
+            ],
         },
     ],
 })


### PR DESCRIPTION
This PR makes `es/no-arrow-functions` fixable.

Example:

`() => 1` to `function() { return 1 }`
`() => this.fn()` to `function() { return this.fn() }.bind(this)`
`() => { return 1 }` to `function() { return 1 }`
`() => { return this.fn() }` to `function() { return this.fn() }.bind(this)`
