### PR TITLE
[Update] Make `es/no-template-literals` fixable

### DIFF
--- a/docs/rules/no-template-literals.md
+++ b/docs/rules/no-template-literals.md
@@ -2,11 +2,21 @@
 
 This rule reports ES2015 template literals as errors.
 
+- :wrench: The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
 ## Examples
 
 ⛔ Examples of **incorrect** code for this rule:
 
 ```js
 const a1 = `foo`
-const a2 = tag`foo`
+const a2 = `foo${bar}baz`
+const a3 = tag`foo`
+```
+
+👌 Examples of **correct** code for this rule:
+
+```js
+const a1 = "foo"
+const a2 = "foo"+bar+"baz"
 ```

--- a/lib/rules/no-template-literals.js
+++ b/lib/rules/no-template-literals.js
@@ -4,6 +4,44 @@
  */
 "use strict"
 
+/**
+ * Checks whether it is string literal
+ * @param  {string} s string source code
+ * @returns {boolean} true: is string literal source code
+ */
+function isStringLiteralCode(s) {
+    return (
+        (s.startsWith("'") && s.endsWith("'")) ||
+        (s.startsWith('"') && s.endsWith('"'))
+    )
+}
+
+/**
+ * Transform template literal to string concatenation.
+ * @param  {ASTNode} node TemplateLiteral node.(not within TaggedTemplateExpression)
+ * @param  {SourceCode} sourceCode SourceCode
+ * @returns {string} After transformation
+ */
+function templateLiteralToStringConcat(node, sourceCode) {
+    const ss = []
+    node.quasis.forEach((q, i) => {
+        const value = q.value.cooked
+        if (value) {
+            ss.push(JSON.stringify(value))
+        }
+
+        if (i < node.expressions.length) {
+            const e = node.expressions[i]
+            const text = sourceCode.getText(e)
+            ss.push(text)
+        }
+    })
+    if (!ss.length || !isStringLiteralCode(ss[0])) {
+        ss.unshift(`""`)
+    }
+    return ss.join("+")
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -13,18 +51,33 @@ module.exports = {
             url:
                 "https://github.com/mysticatea/eslint-plugin-es/blob/v1.1.0/docs/rules/no-template-literals.md",
         },
-        fixable: null,
+        fixable: "code",
         schema: [],
         messages: {
             forbidden: "ES2015 template literals are forbidden.",
         },
     },
     create(context) {
+        const sourceCode = context.getSourceCode()
         return {
             "TaggedTemplateExpression, :not(TaggedTemplateExpression) > TemplateLiteral"(
                 node
             ) {
-                context.report({ node, messageId: "forbidden" })
+                context.report({
+                    node,
+                    messageId: "forbidden",
+                    fix:
+                        node.type === "TemplateLiteral"
+                            ? fixer =>
+                                  fixer.replaceText(
+                                      node,
+                                      templateLiteralToStringConcat(
+                                          node,
+                                          sourceCode
+                                      )
+                                  )
+                            : undefined,
+                })
             },
         }
     },

--- a/tests/lib/rules/no-template-literals.js
+++ b/tests/lib/rules/no-template-literals.js
@@ -8,19 +8,80 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-template-literals.js")
 
 new RuleTester().run("no-template-literals", rule, {
-    valid: ["'foo'", '"bar"'],
+    valid: [
+        "'foo'",
+        '"bar"',
+        `
+const a1 = "foo"
+const a2 = "foo"+bar+"baz"
+    `,
+    ],
     invalid: [
         {
             code: "`foo`",
+            output: `"foo"`,
             errors: ["ES2015 template literals are forbidden."],
         },
         {
             code: "tag`foo`",
+            output: null,
             errors: ["ES2015 template literals are forbidden."],
         },
         {
             //eslint-disable-next-line no-template-curly-in-string
             code: "`foo${a}bar${b}baz`",
+            output: `"foo"+a+"bar"+b+"baz"`,
+            errors: ["ES2015 template literals are forbidden."],
+        },
+        {
+            code: `
+const a1 = \`foo\`
+const a2 = \`foo\${bar}baz\`
+const a3 = tag\`foo\`
+            `,
+            output: `
+const a1 = "foo"
+const a2 = "foo"+bar+"baz"
+const a3 = tag\`foo\`
+            `,
+            errors: [
+                "ES2015 template literals are forbidden.",
+                "ES2015 template literals are forbidden.",
+                "ES2015 template literals are forbidden.",
+            ],
+        },
+        {
+            //eslint-disable-next-line no-template-curly-in-string
+            code: "`${a}${b}`",
+            output: `""+a+b`,
+            errors: ["ES2015 template literals are forbidden."],
+        },
+        {
+            code: "``",
+            output: `""`,
+            errors: ["ES2015 template literals are forbidden."],
+        },
+        {
+            //eslint-disable-next-line no-template-curly-in-string
+            code: '`${""}`',
+            output: `""`,
+            errors: ["ES2015 template literals are forbidden."],
+        },
+        {
+            //eslint-disable-next-line no-template-curly-in-string
+            code: "`${''}`",
+            output: `''`,
+            errors: ["ES2015 template literals are forbidden."],
+        },
+        {
+            code: "`\n\t '\"\\`\\$\\${`",
+            output: `"\\n\\t '\\"\`$\${"`,
+            errors: ["ES2015 template literals are forbidden."],
+        },
+        {
+            //eslint-disable-next-line no-template-curly-in-string
+            code: "`${'abc'}`",
+            output: `'abc'`,
             errors: ["ES2015 template literals are forbidden."],
         },
     ],


### PR DESCRIPTION
This PR makes `es/no-template-literals` fixable.

It does not target tagged template literals.