### PR TITLE
Return statement on separate line fix

### DIFF
--- a/lib/rules/no-arrow-functions.js
+++ b/lib/rules/no-arrow-functions.js
@@ -41,14 +41,13 @@ module.exports = {
                 token => token.type === "Punctuator" && token.value === "=>"
             )
 
-            const bodyText = sourceCode.text.slice(
-                arrowToken.range[1],
-                node.range[1]
-            ).trim()
+            const bodyText = sourceCode.text
+                .slice(arrowToken.range[1], node.range[1])
+                .trim()
             if (node.body.type === "BlockStatement") {
-                return `function(${paramText})${bodyText}`
+                return `function(${paramText}) ${bodyText}`
             }
-            return `function(${paramText}){return ${bodyText}}`
+            return `function(${paramText}){return  ${bodyText}}`
         }
 
         /**

--- a/lib/rules/no-arrow-functions.js
+++ b/lib/rules/no-arrow-functions.js
@@ -44,7 +44,7 @@ module.exports = {
             const bodyText = sourceCode.text.slice(
                 arrowToken.range[1],
                 node.range[1]
-            )
+            ).trim()
             if (node.body.type === "BlockStatement") {
                 return `function(${paramText})${bodyText}`
             }


### PR DESCRIPTION
A simple example for current behavior is
```
a = () => 
    () => 100
```
which is fixed to
```
a = function(){return  
    function(){return 100}}
```
Since return statements in JS cannot be written on a separate line it will fail and prompt `Identifier expected.`
With this change it will fix to
```
a = function(){return function(){return 100}}
```
In my case this is useful for converting coffeescript to working js with angular, which does not work very well with arrow functions. I think it could also be useful for other nested functions or just long functions put on separate lines for clarity.