### PR TITLE
Make `no-property-shorthands` autofixable

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -102,7 +102,7 @@ The `extends: "plugin:es/no-es2015"` config enables the following rules.
 | [es/no-object-super-properties](./no-object-super-properties.md) | disallow `super` property accesses in object literals. |  |
 | [es/no-octal-numeric-literals](./no-octal-numeric-literals.md) | disallow octal numeric literals. |  |
 | [es/no-promise](./no-promise.md) | disallow the `Promise` class. |  |
-| [es/no-property-shorthands](./no-property-shorthands.md) | disallow property shorthands. |  |
+| [es/no-property-shorthands](./no-property-shorthands.md) | disallow property shorthands. | 🔧 |
 | [es/no-proxy](./no-proxy.md) | disallow the `Proxy` class. |  |
 | [es/no-reflect](./no-reflect.md) | disallow the `Reflect` class. |  |
 | [es/no-regexp-u-flag](./no-regexp-u-flag.md) | disallow RegExp `u` flag. |  |

--- a/docs/rules/no-property-shorthands.md
+++ b/docs/rules/no-property-shorthands.md
@@ -1,5 +1,7 @@
 # disallow property shorthands (es/no-property-shorthands)
 
+- 🔧 The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
 This rule reports ES2015 property shorthands as errors.
 
 ## Examples

--- a/lib/rules/no-property-shorthands.js
+++ b/lib/rules/no-property-shorthands.js
@@ -13,18 +13,64 @@ module.exports = {
             url:
                 "http://mysticatea.github.io/eslint-plugin-es/rules/no-property-shorthands.html",
         },
-        fixable: null,
+        fixable: "code",
         schema: [],
         messages: {
             forbidden: "ES2015 property shorthands are forbidden.",
         },
     },
     create(context) {
+        const sourceCode = context.getSourceCode()
+
+        /**
+         * Fixes a FunctionExpression node by making it into a longform property.
+         * @param {SourceCodeFixer} fixer The fixer object
+         * @param {ASTNode} node A `Property` node that has a `FunctionExpression` as its value
+         * @returns {object} A fix for this node
+         */
+        function makeFunctionLongform(fixer, node) {
+            const firstKeyToken = node.computed
+                ? sourceCode.getTokens(node).find(token => token.value === "[")
+                : sourceCode.getFirstToken(node.key)
+            const lastKeyToken = node.computed
+                ? sourceCode
+                      .getTokensBetween(node.key, node.value)
+                      .find(token => token.value === "]")
+                : sourceCode.getLastToken(node.key)
+            const keyText = sourceCode.text.slice(
+                firstKeyToken.range[0],
+                lastKeyToken.range[1]
+            )
+            let functionHeader = "function"
+
+            if (node.value.async) {
+                functionHeader = `async ${functionHeader}`
+            }
+            if (node.value.generator) {
+                functionHeader = `${functionHeader}*`
+            }
+
+            return fixer.replaceTextRange(
+                [node.range[0], lastKeyToken.range[1]],
+                `${keyText}: ${functionHeader}`
+            )
+        }
+
         return {
             "ObjectExpression > :matches(Property[method=true], Property[shorthand=true])"(
                 node
             ) {
-                context.report({ node, messageId: "forbidden" })
+                context.report({
+                    node,
+                    messageId: "forbidden",
+                    fix: node.method
+                        ? fixer => makeFunctionLongform(fixer, node)
+                        : fixer =>
+                              fixer.insertTextAfter(
+                                  node.key,
+                                  `: ${node.key.name}`
+                              ),
+                })
             },
         }
     },

--- a/lib/rules/no-property-shorthands.js
+++ b/lib/rules/no-property-shorthands.js
@@ -4,6 +4,8 @@
  */
 "use strict"
 
+const { isOpeningBracketToken, isClosingBracketToken } = require("eslint-utils")
+
 module.exports = {
     meta: {
         docs: {
@@ -30,12 +32,10 @@ module.exports = {
          */
         function makeFunctionLongform(fixer, node) {
             const firstKeyToken = node.computed
-                ? sourceCode.getTokens(node).find(token => token.value === "[")
+                ? sourceCode.getTokenBefore(node.key, isOpeningBracketToken)
                 : sourceCode.getFirstToken(node.key)
             const lastKeyToken = node.computed
-                ? sourceCode
-                      .getTokensBetween(node.key, node.value)
-                      .find(token => token.value === "]")
+                ? sourceCode.getTokenAfter(node.key, isClosingBracketToken)
                 : sourceCode.getLastToken(node.key)
             const keyText = sourceCode.text.slice(
                 firstKeyToken.range[0],

--- a/tests/lib/rules/no-property-shorthands.js
+++ b/tests/lib/rules/no-property-shorthands.js
@@ -20,18 +20,32 @@ new RuleTester().run("no-property-shorthands", rule, {
     invalid: [
         {
             code: "({ a })",
+            output: "({ a: a })",
             errors: ["ES2015 property shorthands are forbidden."],
         },
         {
             code: "({ a() {} })",
+            output: "({ a: function() {} })",
             errors: ["ES2015 property shorthands are forbidden."],
         },
         {
             code: "({ * a() {} })",
+            output: "({ a: function*() {} })",
             errors: ["ES2015 property shorthands are forbidden."],
         },
         {
             code: "({ [a]() {} })",
+            output: "({ [a]: function() {} })",
+            errors: ["ES2015 property shorthands are forbidden."],
+        },
+        {
+            code: "({ async a() {} })",
+            output: "({ a: async function() {} })",
+            errors: ["ES2015 property shorthands are forbidden."],
+        },
+        {
+            code: "({ async * [a]() {} })",
+            output: "({ [a]: async function*() {} })",
             errors: ["ES2015 property shorthands are forbidden."],
         },
     ],


### PR DESCRIPTION
This PR makes `es/no-property-shorthands` autofixable.


