### PR TITLE
Make `no-trailing-function-commas` autofixable

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -38,7 +38,7 @@ The `extends: "plugin:es/no-es2017"` config enables the following rules.
 | [es/no-object-getownpropertydescriptors](./no-object-getownpropertydescriptors.md) | disallow the `Object.getOwnPropertyDescriptors` method. |  |
 | [es/no-object-values](./no-object-values.md) | disallow the `Object.values` method. |  |
 | [es/no-shared-array-buffer](./no-shared-array-buffer.md) | disallow the `SharedArrayBuffer` class. |  |
-| [es/no-trailing-function-commas](./no-trailing-function-commas.md) | disallow trailing commas in parameter/argument lists. |  |
+| [es/no-trailing-function-commas](./no-trailing-function-commas.md) | disallow trailing commas in parameter/argument lists. | 🔧 |
 
 ## ES2016
 

--- a/docs/rules/no-trailing-function-commas.md
+++ b/docs/rules/no-trailing-function-commas.md
@@ -1,5 +1,7 @@
 # disallow trailing commas in parameter/argument lists (es/no-trailing-function-commas)
 
+- 🔧 The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
 This rule reports ES2017 [trailing commas in parameter/argument lists](https://github.com/tc39/proposal-trailing-function-commas#readme) as errors.
 
 ## Examples

--- a/lib/rules/no-trailing-function-commas.js
+++ b/lib/rules/no-trailing-function-commas.js
@@ -16,7 +16,7 @@ module.exports = {
             url:
                 "http://mysticatea.github.io/eslint-plugin-es/rules/no-trailing-function-commas.html",
         },
-        fixable: null,
+        fixable: "code",
         schema: [],
         messages: {
             forbidden:
@@ -35,13 +35,25 @@ module.exports = {
                 const lastParam = node.params[length - 1]
                 const token = sourceCode.getTokenAfter(lastParam)
                 if (isCommaToken(token)) {
-                    context.report({ loc: token.loc, messageId: "forbidden" })
+                    context.report({
+                        loc: token.loc,
+                        messageId: "forbidden",
+                        fix(fixer) {
+                            return fixer.remove(token)
+                        },
+                    })
                 }
             },
             "CallExpression, NewExpression"(node) {
                 const token = sourceCode.getLastToken(node, 1)
                 if (node.arguments.length >= 1 && isCommaToken(token)) {
-                    context.report({ loc: token.loc, messageId: "forbidden" })
+                    context.report({
+                        loc: token.loc,
+                        messageId: "forbidden",
+                        fix(fixer) {
+                            return fixer.remove(token)
+                        },
+                    })
                 }
             },
         }

--- a/tests/lib/rules/no-trailing-function-commas.js
+++ b/tests/lib/rules/no-trailing-function-commas.js
@@ -23,48 +23,56 @@ new RuleTester().run("no-trailing-function-commas", rule, {
     invalid: [
         {
             code: "function f(a,) {}",
+            output: "function f(a) {}",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "(function(a,) {})",
+            output: "(function(a) {})",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "(a,) => {}",
+            output: "(a) => {}",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "({ f(a,) {} })",
+            output: "({ f(a) {} })",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "class A { f(a,) {} }",
+            output: "class A { f(a) {} }",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "(class { f(a,) {} })",
+            output: "(class { f(a) {} })",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "f(a,)",
+            output: "f(a)",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],
         },
         {
             code: "new F(a,)",
+            output: "new F(a)",
             errors: [
                 "ES2017 trailing commas in parameter/argument lists are forbidden.",
             ],


### PR DESCRIPTION
This PR makes `es/no-trailing-function-commas` autofixable.