### PR TITLE
Add a `no-2020` preset for ES2020 rules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ This plugin provides the following configs.
 
 | Config ID | Description |
 |:----------|:------------|
+| `plugin:es/no-2020` | enable all rules which disallow ES2020 syntax.
 | `plugin:es/no-2019` | enable all rules which disallow ES2019 syntax.
 | `plugin:es/no-2018` | enable all rules which disallow ES2018 syntax.
 | `plugin:es/no-2017` | enable all rules which disallow ES2017 syntax.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -6,7 +6,8 @@ This plugin provides the following rules.
 
 ## ES2020
 
-There is no config which enables all rules in this category.
+The `extends: "plugin:es/no-2020"` config enables the following rules.
+
 | Rule ID | Description |    |
 |:--------|:------------|:--:|
 | [es/no-bigint](./no-bigint.md) | disallow `bigint` syntax and built-ins. |  |

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,14 @@
 
 module.exports = {
     configs: {
+        "no-2020": {
+            rules: {
+                "es/no-bigint": "error",
+                "es/no-dynamic-import": "error",
+                "es/no-global-this": "error",
+                "es/no-promise-all-settled": "error",
+            },
+        },
         "no-2019": {
             rules: {
                 "es/no-json-superset": "error",


### PR DESCRIPTION
My understanding is that you do not keep a preset for the current year until the year has elapsed to avoid breaking changes, but I think it's reasonable to expect breaking changes for the current year.
I know I would prefer to use a recommended preset for 2020 and deal with new violations that come up on minor bumps.