### PR TITLE
Add the `es` plugin as part of any preset

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@
 module.exports = {
     configs: {
         "no-2019": {
+            plugins: ["es"],
             rules: {
                 "es/no-json-superset": "error",
                 "es/no-optional-catch-binding": "error",
@@ -14,6 +15,7 @@ module.exports = {
             },
         },
         "no-2018": {
+            plugins: ["es"],
             rules: {
                 "es/no-async-iteration": "error",
                 "es/no-malformed-template-literals": "error",
@@ -25,6 +27,7 @@ module.exports = {
             },
         },
         "no-2017": {
+            plugins: ["es"],
             rules: {
                 "es/no-async-functions": "error",
                 "es/no-atomics": "error",
@@ -36,11 +39,13 @@ module.exports = {
             },
         },
         "no-2016": {
+            plugins: ["es"],
             rules: {
                 "es/no-exponential-operators": "error",
             },
         },
         "no-2015": {
+            plugins: ["es"],
             rules: {
                 "es/no-array-from": "error",
                 "es/no-array-of": "error",
@@ -110,6 +115,7 @@ module.exports = {
             },
         },
         "no-5": {
+            plugins: ["es"],
             rules: {
                 "es/no-accessor-properties": "error",
                 "es/no-array-isarray": "error",


### PR DESCRIPTION
This is a very common pattern in other plugin, for example:

- https://github.com/yannickcr/eslint-plugin-react/blob/master/index.js#L116-L118
- https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/src/index.js#L44-L46