### PR TITLE
Add `es/no-nullish-coalescing-operators` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -12,6 +12,7 @@ There is no config which enables all rules in this category.
 | [es/no-bigint](./no-bigint.md) | disallow `bigint` syntax and built-ins. |  |
 | [es/no-dynamic-import](./no-dynamic-import.md) | disallow `import()` syntax. |  |
 | [es/no-global-this](./no-global-this.md) | disallow the `globalThis` variable. |  |
+| [es/no-nullish-coalescing-operators](./no-nullish-coalescing-operators.md) | disallow nullish coalescing operators. |  |
 | [es/no-promise-all-settled](./no-promise-all-settled.md) | disallow `Promise.allSettled` function. |  |
 
 ## ES2019

--- a/docs/rules/no-nullish-coalescing-operators.md
+++ b/docs/rules/no-nullish-coalescing-operators.md
@@ -1,0 +1,23 @@
+# disallow nullish coalescing operators (es/no-nullish-coalescing-operators)
+
+This rule reports ES2020 [Nullish Coalescing operators](https://github.com/tc39/proposal-nullish-coalescing) as errors.
+
+## Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint es/no-nullish-coalescing-operators: error */
+var x = a ?? b
+" />
+
+👌 Examples of **correct** code for this rule:
+
+<eslint-playground type="good" code="/*eslint es/no-nullish-coalescing-operators: error */
+var x = a || b
+var x = a != null ? a : b
+" />
+
+## 📚 References
+
+- [Rule source](https://github.com/mysticatea/eslint-plugin-es/blob/v3.0.1/lib/rules/no-nullish-coalescing-operators.js)
+- [Test source](https://github.com/mysticatea/eslint-plugin-es/blob/v3.0.1/tests/lib/rules/no-nullish-coalescing-operators.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,6 +179,7 @@ module.exports = {
         "no-math-trunc": require("./rules/no-math-trunc"),
         "no-modules": require("./rules/no-modules"),
         "no-new-target": require("./rules/no-new-target"),
+        "no-nullish-coalescing-operators": require("./rules/no-nullish-coalescing-operators"),
         "no-number-epsilon": require("./rules/no-number-epsilon"),
         "no-number-isfinite": require("./rules/no-number-isfinite"),
         "no-number-isinteger": require("./rules/no-number-isinteger"),

--- a/lib/rules/no-nullish-coalescing-operators.js
+++ b/lib/rules/no-nullish-coalescing-operators.js
@@ -4,15 +4,6 @@
  */
 "use strict"
 
-/**
- * Checks if the given token is a nullish coalescing operator or not.
- * @param {Token} token - The token to check.
- * @returns {boolean} `true` if the token is a nullish coalescing operator.
- */
-function isNullishCoalescingOperator(token) {
-    return token.value === "??" && token.type === "Punctuator"
-}
-
 module.exports = {
     meta: {
         docs: {
@@ -32,12 +23,8 @@ module.exports = {
     create(context) {
         return {
             "LogicalExpression[operator='??']"(node) {
-                const sourceCode = context.getSourceCode()
                 context.report({
-                    node: sourceCode.getFirstToken(
-                        node,
-                        isNullishCoalescingOperator
-                    ),
+                    node: context.getSourceCode().getTokenAfter(node.left),
                     messageId: "forbidden",
                 })
             },

--- a/lib/rules/no-nullish-coalescing-operators.js
+++ b/lib/rules/no-nullish-coalescing-operators.js
@@ -4,6 +4,15 @@
  */
 "use strict"
 
+/**
+ * Checks if the given token is a nullish coalescing operator or not.
+ * @param {Token} token - The token to check.
+ * @returns {boolean} `true` if the token is a nullish coalescing operator.
+ */
+function isNullishCoalescingOperator(token) {
+    return token.value === "??" && token.type === "Punctuator"
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -24,7 +33,9 @@ module.exports = {
         return {
             "LogicalExpression[operator='??']"(node) {
                 context.report({
-                    node: context.getSourceCode().getTokenAfter(node.left),
+                    node: context
+                        .getSourceCode()
+                        .getTokenAfter(node.left, isNullishCoalescingOperator),
                     messageId: "forbidden",
                 })
             },

--- a/lib/rules/no-nullish-coalescing-operators.js
+++ b/lib/rules/no-nullish-coalescing-operators.js
@@ -1,0 +1,46 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+/**
+ * Checks if the given token is a nullish coalescing operator or not.
+ * @param {Token} token - The token to check.
+ * @returns {boolean} `true` if the token is a nullish coalescing operator.
+ */
+function isNullishCoalescingOperator(token) {
+    return token.value === "??" && token.type === "Punctuator"
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow nullish coalescing operators.",
+            category: "ES2020",
+            recommended: false,
+            url:
+                "http://mysticatea.github.io/eslint-plugin-es/rules/no-nullish-coalescing-operators.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES2020 nullish coalescing operators are forbidden.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            "LogicalExpression[operator='??']"(node) {
+                const sourceCode = context.getSourceCode()
+                context.report({
+                    node: sourceCode.getFirstToken(
+                        node,
+                        isNullishCoalescingOperator
+                    ),
+                    messageId: "forbidden",
+                })
+            },
+        }
+    },
+}

--- a/tests/lib/rules/no-nullish-coalescing-operators.js
+++ b/tests/lib/rules/no-nullish-coalescing-operators.js
@@ -1,5 +1,5 @@
 /**
- * @author Toru Nagashima <https://github.com/mysticatea>
+ * @author Yosuke Ota <https://github.com/ota-meshi>
  * See LICENSE file in root directory for full license.
  */
 "use strict"

--- a/tests/lib/rules/no-nullish-coalescing-operators.js
+++ b/tests/lib/rules/no-nullish-coalescing-operators.js
@@ -1,0 +1,47 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-nullish-coalescing-operators.js")
+
+if (!RuleTester.isSupported(2020)) {
+    //eslint-disable-next-line no-console
+    console.log("Skip the tests of no-nullish-coalescing-operators.")
+    return
+}
+
+new RuleTester().run("no-nullish-coalescing-operators", rule, {
+    valid: ["a ? b : c", "a && b", "a || b"],
+    invalid: [
+        {
+            code: "a??b",
+            errors: [
+                {
+                    message:
+                        "ES2020 nullish coalescing operators are forbidden.",
+                    column: 2,
+                    endColumn: 4,
+                },
+            ],
+        },
+        {
+            code: ` /* ?? comment ?? */
+            a /* ?? comment ?? */
+            ?? /* ?? comment ?? */
+            b /* ?? comment ?? */`,
+            errors: [
+                {
+                    message:
+                        "ES2020 nullish coalescing operators are forbidden.",
+                    line: 3,
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 15,
+                },
+            ],
+        },
+    ],
+})

--- a/tests/lib/rules/no-nullish-coalescing-operators.js
+++ b/tests/lib/rules/no-nullish-coalescing-operators.js
@@ -43,5 +43,39 @@ new RuleTester().run("no-nullish-coalescing-operators", rule, {
                 },
             ],
         },
+        {
+            code: "a ?? b ?? c",
+            errors: [
+                {
+                    message:
+                        "ES2020 nullish coalescing operators are forbidden.",
+                    column: 3,
+                    endColumn: 5,
+                },
+                {
+                    message:
+                        "ES2020 nullish coalescing operators are forbidden.",
+                    column: 8,
+                    endColumn: 10,
+                },
+            ],
+        },
+        {
+            code: "(a ?? b) ?? c",
+            errors: [
+                {
+                    message:
+                        "ES2020 nullish coalescing operators are forbidden.",
+                    column: 4,
+                    endColumn: 6,
+                },
+                {
+                    message:
+                        "ES2020 nullish coalescing operators are forbidden.",
+                    column: 10,
+                    endColumn: 12,
+                },
+            ],
+        },
     ],
 })


### PR DESCRIPTION
This PR adds `es/no-nullish-coalescing-operators` rule.

`es/no-nullish-coalescing-operators` rule reports ES2020 [Nullish Coalescing operators](https://github.com/tc39/proposal-nullish-coalescing) as errors.