### PR TITLE
Add `es/no-import-meta` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -12,6 +12,7 @@ There is no config which enables all rules in this category.
 | [es/no-bigint](./no-bigint.md) | disallow `bigint` syntax and built-ins. |  |
 | [es/no-dynamic-import](./no-dynamic-import.md) | disallow `import()` syntax. |  |
 | [es/no-global-this](./no-global-this.md) | disallow the `globalThis` variable. |  |
+| [es/no-import-meta](./no-import-meta.md) | disallow `new.target` meta property. |  |
 | [es/no-promise-all-settled](./no-promise-all-settled.md) | disallow `Promise.allSettled` function. |  |
 
 ## ES2019

--- a/docs/rules/no-import-meta.md
+++ b/docs/rules/no-import-meta.md
@@ -1,0 +1,16 @@
+# disallow `import.meta` meta property (es/no-import-meta)
+
+This rule reports ES2020 [import.meta](https://github.com/tc39/proposal-import-meta) as errors.
+
+## Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint es/no-import-meta: error */
+import.meta
+" />
+
+## 📚 References
+
+- [Rule source](https://github.com/mysticatea/eslint-plugin-es/blob/v3.0.1/lib/rules/no-import-meta.js)
+- [Test source](https://github.com/mysticatea/eslint-plugin-es/blob/v3.0.1/tests/lib/rules/no-import-meta.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,6 +155,7 @@ module.exports = {
         "no-for-of-loops": require("./rules/no-for-of-loops"),
         "no-generators": require("./rules/no-generators"),
         "no-global-this": require("./rules/no-global-this"),
+        "no-import-meta": require("./rules/no-import-meta"),
         "no-json-superset": require("./rules/no-json-superset"),
         "no-json": require("./rules/no-json"),
         "no-keyword-properties": require("./rules/no-keyword-properties"),

--- a/lib/rules/no-import-meta.js
+++ b/lib/rules/no-import-meta.js
@@ -1,0 +1,30 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow `import.meta` meta property.",
+            category: "ES2020",
+            recommended: false,
+            url:
+                "http://mysticatea.github.io/eslint-plugin-es/rules/no-import-meta.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES2020 'import.meta' meta property is forbidden.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            "MetaProperty[meta.name='import'][property.name='meta']"(node) {
+                context.report({ node, messageId: "forbidden" })
+            },
+        }
+    },
+}

--- a/tests/lib/rules/no-import-meta.js
+++ b/tests/lib/rules/no-import-meta.js
@@ -1,0 +1,26 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-import-meta.js")
+
+if (!RuleTester.isSupported(2020)) {
+    //eslint-disable-next-line no-console
+    console.log("Skip the tests of no-import-meta.")
+    return
+}
+
+new RuleTester({
+    parserOptions: { sourceType: "module" },
+}).run("no-import-meta", rule, {
+    valid: ["import * as Foo from 'foo'", "import('foo')"],
+    invalid: [
+        {
+            code: "import.meta",
+            errors: ["ES2020 'import.meta' meta property is forbidden."],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds `es/no-import-meta` rule.

`es/no-import-meta` rule reports ES2020 [import.meta](https://github.com/tc39/proposal-import-meta) as errors.