### PR TITLE
Fix broken `es/no-object-defineproperty` and `es/no-object-getownpropertynames` docs

### DIFF
--- a/docs/rules/no-object-defineproperty.md
+++ b/docs/rules/no-object-defineproperty.md
@@ -7,7 +7,7 @@ This rule reports ES5 `Object.defineProperty` method as errors.
 ⛔ Examples of **incorrect** code for this rule:
 
 <eslint-playground type="bad" code="/*eslint es/no-object-defineproperty: error */
-Object.defineProperty(obj, "prop", {})
+Object.defineProperty(obj, &quot;prop&quot;, {})
 " />
 
 ## 📚 References

--- a/docs/rules/no-object-getownpropertynames.md
+++ b/docs/rules/no-object-getownpropertynames.md
@@ -7,7 +7,7 @@ This rule reports ES5 `Object.getOwnPropertyNames` method as errors.
 ⛔ Examples of **incorrect** code for this rule:
 
 <eslint-playground type="bad" code="/*eslint es/no-object-getownpropertynames: error */
-Object.getOwnPropertyNames(obj, "prop", {})
+Object.getOwnPropertyNames(obj, &quot;prop&quot;, {})
 " />
 
 ## 📚 References


### PR DESCRIPTION
This PR fixes broken `es/no-object-defineproperty` and `es/no-object-getownpropertynames` documents.

- before:

![image](https://user-images.githubusercontent.com/16508807/84563466-c6c94400-ad96-11ea-948c-54022abe5ebe.png)

- after:

![image](https://user-images.githubusercontent.com/16508807/84563474-d8aae700-ad96-11ea-8b25-0a2f4bd821fa.png)

