### PR TITLE
Upgrade vue-eslint-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "opener": "^1.5.1",
     "rimraf": "^3.0.0",
     "semver": "^6.3.0",
-    "vue-eslint-editor": "^0.2.0",
+    "vue-eslint-editor": "^1.1.0",
     "vuepress": "^1.2.0"
   },
   "scripts": {


### PR DESCRIPTION
This PR upgrade vue-eslint-editor.

Older Monaco editors can't parse `?.` well. Upgrade Monaco editor to understand the ES2020 syntax.