### PR TITLE
Add es/no-numeric-separators rule

### DIFF
--- a/docs/.vuepress/components/eslint-playground.vue
+++ b/docs/.vuepress/components/eslint-playground.vue
@@ -67,7 +67,7 @@ export default {
                 },
                 rules: {},
                 parserOptions: {
-                    ecmaVersion: 2020,
+                    ecmaVersion: 2021,
                     sourceType: "module",
                 },
             },

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -4,6 +4,13 @@ This plugin provides the following rules.
 
 - 🔧 mark means that the `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by the rule.
 
+## ES2021
+
+There is no config which enables all rules in this category.
+| Rule ID | Description |    |
+|:--------|:------------|:--:|
+| [es/no-numeric-separators](./no-numeric-separators.md) | disallow numeric separators. |  |
+
 ## ES2020
 
 There is no config which enables all rules in this category.
@@ -13,7 +20,7 @@ There is no config which enables all rules in this category.
 | [es/no-dynamic-import](./no-dynamic-import.md) | disallow `import()` syntax. |  |
 | [es/no-export-ns-from](./no-export-ns-from.md) | disallow `export * as ns`. |  |
 | [es/no-global-this](./no-global-this.md) | disallow the `globalThis` variable. |  |
-| [es/no-import-meta](./no-import-meta.md) | disallow `new.target` meta property. |  |
+| [es/no-import-meta](./no-import-meta.md) | disallow `import.meta` meta property. |  |
 | [es/no-nullish-coalescing-operators](./no-nullish-coalescing-operators.md) | disallow nullish coalescing operators. |  |
 | [es/no-promise-all-settled](./no-promise-all-settled.md) | disallow `Promise.allSettled` function. |  |
 

--- a/docs/rules/no-numeric-separators.md
+++ b/docs/rules/no-numeric-separators.md
@@ -1,0 +1,18 @@
+# disallow numeric separators (es/no-numeric-separators)
+
+- 🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule reports ES2021 [numeric separators](https://github.com/tc39/proposal-numeric-separator) as errors.
+
+## Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint es/no-numeric-separators: error */
+let a = 123_456
+" />
+
+## 📚 References
+
+- [Rule source](https://github.com/mysticatea/eslint-plugin-es/blob/v3.0.1/lib/rules/no-numeric-separators.js)
+- [Test source](https://github.com/mysticatea/eslint-plugin-es/blob/v3.0.1/tests/lib/rules/no-numeric-separators.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,7 @@ module.exports = {
         "no-number-minsafeinteger": require("./rules/no-number-minsafeinteger"),
         "no-number-parsefloat": require("./rules/no-number-parsefloat"),
         "no-number-parseint": require("./rules/no-number-parseint"),
+        "no-numeric-separators": require("./rules/no-numeric-separators"),
         "no-object-assign": require("./rules/no-object-assign"),
         "no-object-defineproperties": require("./rules/no-object-defineproperties"),
         "no-object-defineproperty": require("./rules/no-object-defineproperty"),

--- a/lib/rules/no-numeric-separators.js
+++ b/lib/rules/no-numeric-separators.js
@@ -1,0 +1,52 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+/**
+ * Remove the numeric separators.
+ * @param  {string} raw The raw string of numeric literals
+ * @returns {string} The string with the separators removed.
+ */
+function removeNumericSeparators(raw) {
+    return raw.replace(/_/gu, "")
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow numeric separators.",
+            category: "ES2021",
+            recommended: false,
+            url:
+                "http://mysticatea.github.io/eslint-plugin-es/rules/no-numeric-separators.html",
+        },
+        fixable: "code",
+        messages: {
+            forbidden: "ES2021 numeric separators are forbidden.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            Literal(node) {
+                if (
+                    (typeof node.value === "number" || node.bigint != null) &&
+                    node.raw.includes("_")
+                ) {
+                    context.report({
+                        node,
+                        messageId: "forbidden",
+                        fix: fixer =>
+                            fixer.replaceText(
+                                node,
+                                removeNumericSeparators(node.raw)
+                            ),
+                    })
+                }
+            },
+        }
+    },
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@vuepress/plugin-pwa": "^1.2.0",
     "acorn": "^7.1.0",
     "babel-eslint": "^10.0.1",
-    "codecov": "^3.5.0",
+    "codecov": "3.7.0",
     "eslint": "^7.10.0",
     "eslint4b": "^7.10.0",
     "espree": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "regexpp": "^3.0.0"
   },
   "devDependencies": {
-    "@mysticatea/eslint-plugin": "^11.0.0",
+    "@mysticatea/eslint-plugin": "^13.0.0",
     "@vuepress/plugin-pwa": "^1.2.0",
     "acorn": "^7.1.0",
     "babel-eslint": "^10.0.1",
     "codecov": "^3.5.0",
-    "eslint": "^6.2.2",
-    "eslint4b": "^6.2.2",
+    "eslint": "^7.10.0",
+    "eslint4b": "^7.10.0",
     "espree": "^7.0.0",
     "globals": "^12.0.0",
     "mocha": "^6.2.0",

--- a/scripts/rules.js
+++ b/scripts/rules.js
@@ -8,6 +8,7 @@ const fs = require("fs")
 const path = require("path")
 const libRoot = path.resolve(__dirname, "../lib/rules")
 const categories = {
+    ES2021: { id: "ES2021", rules: [], noConfig: true },
     ES2020: { id: "ES2020", rules: [], noConfig: true },
     ES2019: { id: "ES2019", rules: [] },
     ES2018: { id: "ES2018", rules: [] },

--- a/tests/lib/rules/no-numeric-separators.js
+++ b/tests/lib/rules/no-numeric-separators.js
@@ -1,0 +1,72 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-numeric-separators.js")
+
+if (!RuleTester.isSupported(2021)) {
+    //eslint-disable-next-line no-console
+    console.log("Skip the tests of no-numeric-separators.")
+    return
+}
+
+new RuleTester().run("no-numeric-separators", rule, {
+    valid: [
+        "123456",
+        "-123",
+        "123.456",
+        "123.0",
+        "NaN",
+        "123e-1",
+        "0x11",
+        "0b11",
+        "0o11",
+        "Infinity",
+        "123456n",
+    ],
+    invalid: [
+        {
+            code: "123_456",
+            output: "123456",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "5_000",
+            output: "5000",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "1_234_56",
+            output: "123456",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "5.00_00",
+            output: "5.0000",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "0b11_01",
+            output: "0b1101",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "5e1_000",
+            output: "5e1000",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "0xBE_EF",
+            output: "0xBEEF",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+        {
+            code: "123_456n",
+            output: "123456n",
+            errors: ["ES2021 numeric separators are forbidden."],
+        },
+    ],
+})

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -11,6 +11,7 @@ const semver = require("semver")
 const eslintVersion = new Linter().version
 const ecmaVersion =
     /*eslint-disable @mysticatea/prettier */
+    semver.gte(eslintVersion, "7.8.0") ? 2021 :
     semver.gte(eslintVersion, "6.2.0") ? 2020 :
     semver.gte(eslintVersion, "5.0.0") ? 2019 :
     2018


### PR DESCRIPTION
This PR adds `es/no-numeric-separators` rule.

`es/no-numeric-separators` rule reports ES2021 [numeric separators](https://github.com/tc39/proposal-numeric-separator) as errors.

Notes:  
I fixed the version of codecov used at 3.7.
This is a workaround for working with `Node.js@8`.
