### PR TITLE
Add `es/no-object-create` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -191,6 +191,7 @@ There are multiple configs that enable all rules in this category: `plugin:es/no
 | [es/no-date-now](./no-date-now.md) | disallow the `Date.now` method. |  |
 | [es/no-json](./no-json.md) | disallow the `JSON` class. |  |
 | [es/no-keyword-properties](./no-keyword-properties.md) | disallow reserved words as property names. |  |
+| [es/no-object-create](./no-object-create.md) | disallow the `Object.create` method. |  |
 | [es/no-object-defineproperties](./no-object-defineproperties.md) | disallow the `Object.defineProperties` method. |  |
 | [es/no-object-defineproperty](./no-object-defineproperty.md) | disallow the `Object.defineProperty` method. |  |
 | [es/no-object-freeze](./no-object-freeze.md) | disallow the `Object.freeze` method. |  |

--- a/docs/rules/no-object-create.md
+++ b/docs/rules/no-object-create.md
@@ -1,0 +1,19 @@
+# es/no-object-create
+> disallow the `Object.create` method
+
+- ✅ The following configurations enable this rule: `plugin:es/no-new-in-es5` and `plugin:es/restrict-to-es3`
+
+This rule reports ES5 `Object.create` method as errors.
+
+## Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint es/no-object-create: error */
+Object.create({})
+" />
+
+## 📚 References
+
+- [Rule source](https://github.com/mysticatea/eslint-plugin-es/blob/v4.1.0/lib/rules/no-object-create.js)
+- [Test source](https://github.com/mysticatea/eslint-plugin-es/blob/v4.1.0/tests/lib/rules/no-object-create.js)

--- a/lib/configs/no-new-in-es5.js
+++ b/lib/configs/no-new-in-es5.js
@@ -21,6 +21,7 @@ module.exports = {
         "es/no-date-now": "error",
         "es/no-json": "error",
         "es/no-keyword-properties": "error",
+        "es/no-object-create": "error",
         "es/no-object-defineproperties": "error",
         "es/no-object-defineproperty": "error",
         "es/no-object-freeze": "error",

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,7 @@ module.exports = {
         "no-number-parseint": require("./rules/no-number-parseint"),
         "no-numeric-separators": require("./rules/no-numeric-separators"),
         "no-object-assign": require("./rules/no-object-assign"),
+        "no-object-create": require("./rules/no-object-create"),
         "no-object-defineproperties": require("./rules/no-object-defineproperties"),
         "no-object-defineproperty": require("./rules/no-object-defineproperty"),
         "no-object-entries": require("./rules/no-object-entries"),

--- a/lib/rules/no-object-create.js
+++ b/lib/rules/no-object-create.js
@@ -1,0 +1,43 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const { ReferenceTracker, READ } = require("eslint-utils")
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow the `Object.create` method.",
+            category: "ES5",
+            recommended: false,
+            url:
+                "http://mysticatea.github.io/eslint-plugin-es/rules/no-object-create.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES5 '{{name}}' method is forbidden.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            "Program:exit"() {
+                const tracker = new ReferenceTracker(context.getScope())
+                for (const { node, path } of tracker.iterateGlobalReferences({
+                    Object: {
+                        create: { [READ]: true },
+                    },
+                })) {
+                    context.report({
+                        node,
+                        messageId: "forbidden",
+                        data: { name: path.join(".") },
+                    })
+                }
+            },
+        }
+    },
+}

--- a/tests/lib/rules/no-object-create.js
+++ b/tests/lib/rules/no-object-create.js
@@ -1,0 +1,18 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-object-create.js")
+
+new RuleTester().run("no-object-create", rule, {
+    valid: ["Object", "Object.foo", "let Object = 0; Object.create"],
+    invalid: [
+        {
+            code: "Object.create",
+            errors: ["ES5 'Object.create' method is forbidden."],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds `es/no-object-create` rule.

`es/no-object-create` rule reports ES5 `Object.create()` as errors.

close #60 
