### PR TITLE
Add `es/no-array-string-prototype-at` rule

### DIFF
--- a/docs/rules/no-array-string-prototype-at.md
+++ b/docs/rules/no-array-string-prototype-at.md
@@ -1,0 +1,20 @@
+# es/no-array-string-prototype-at
+> disallow the `{Array,String}.prototype.at()` methods
+
+This rule reports ES2022 [`{Array,String,TypedArray}.prototype.at` methods](https://github.com/tc39/proposal-relative-indexing-method) as errors.
+
+This rule is silent by default because it's hard to know types. You need to configure [the aggressive mode](../#the-aggressive-mode) or TypeScript in order to enable this rule.
+
+## Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint es/no-array-string-prototype-at: [error, { aggressive: true }] */
+foo.at(-1)
+'str'.at(-1)
+" />
+
+## 📚 References
+
+- [Rule source](https://github.com/mysticatea/eslint-plugin-es/blob/v4.1.0/lib/rules/no-array-string-prototype-at.js)
+- [Test source](https://github.com/mysticatea/eslint-plugin-es/blob/v4.1.0/tests/lib/rules/no-array-string-prototype-at.js)

--- a/docs/rules/no-array-string-prototype-at.md
+++ b/docs/rules/no-array-string-prototype-at.md
@@ -14,6 +14,20 @@ foo.at(-1)
 'str'.at(-1)
 " />
 
+## 🔧 Options
+
+This rule has an option.
+
+```yml
+rules:
+  es/no-array-string-prototype-at: [error, { aggressive: false }]
+```
+
+### aggressive: boolean
+
+Configure the aggressive mode for only this rule.
+This is prior to the `settings.es.aggressive` setting.
+
 ## 📚 References
 
 - [Rule source](https://github.com/mysticatea/eslint-plugin-es/blob/v4.1.0/lib/rules/no-array-string-prototype-at.js)

--- a/lib/rules/no-array-string-prototype-at.js
+++ b/lib/rules/no-array-string-prototype-at.js
@@ -1,0 +1,53 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const {
+    definePrototypeMethodHandler,
+} = require("../util/define-prototype-method-handler")
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "disallow the `{Array,String}.prototype.at()` methods.",
+            category: "ES2022",
+            recommended: false,
+            url:
+                "http://mysticatea.github.io/eslint-plugin-es/rules/no-array-string-prototype-at.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES2022 '{{name}}' method is forbidden.",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    aggressive: { type: "boolean" },
+                },
+                additionalProperties: false,
+            },
+        ],
+        type: "problem",
+    },
+    create(context) {
+        return definePrototypeMethodHandler(context, {
+            Array: ["at"],
+            String: ["at"],
+            Int8Array: ["at"],
+            Uint8Array: ["at"],
+            Uint8ClampedArray: ["at"],
+            Int16Array: ["at"],
+            Uint16Array: ["at"],
+            Int32Array: ["at"],
+            Uint32Array: ["at"],
+            Float32Array: ["at"],
+            Float64Array: ["at"],
+            BigInt64Array: ["at"],
+            BigUint64Array: ["at"],
+        })
+    },
+}

--- a/tests/lib/rules/no-array-string-prototype-at.js
+++ b/tests/lib/rules/no-array-string-prototype-at.js
@@ -1,0 +1,377 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const path = require("path")
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-array-string-prototype-at.js")
+const ruleId = "no-array-string-prototype-at"
+
+new RuleTester().run(ruleId, rule, {
+    valid: [
+        "at(-1)",
+        "foo.reverse()",
+        "foo.at(-1)",
+        { code: "at(-1)", settings: { es: { aggressive: true } } },
+        { code: "foo.reverse()", settings: { es: { aggressive: true } } },
+        {
+            code: "foo.at(-1)",
+            options: [{ aggressive: false }],
+            settings: { es: { aggressive: true } },
+        },
+    ],
+    invalid: [
+        {
+            code: "foo.at(-1)",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: true } },
+        },
+        {
+            code: "foo.at(-1)",
+            options: [{ aggressive: true }],
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: false } },
+        },
+        {
+            code: "[1,2,3].at(-1)",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+        },
+        {
+            code: "'123'.at(-1)",
+            errors: ["ES2022 'String.prototype.at' method is forbidden."],
+        },
+    ],
+})
+
+// -----------------------------------------------------------------------------
+// TypeScript
+// -----------------------------------------------------------------------------
+const parser = require.resolve("@typescript-eslint/parser")
+const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const project = "tsconfig.json"
+const filename = path.join(tsconfigRootDir, "test.ts")
+
+new RuleTester({ parser }).run(`${ruleId} TS`, rule, {
+    valid: [
+        { filename, code: "at(-1)" },
+        { filename, code: "foo.reverse()" },
+        { filename, code: "foo.at(-1)" },
+        { filename, code: "let foo = {}; foo.at(-1)" },
+        {
+            filename,
+            code: "at(-1)",
+            settings: { es: { aggressive: true } },
+        },
+        {
+            filename,
+            code: "foo.reverse()",
+            settings: { es: { aggressive: true } },
+        },
+
+        // `Array` is unknown type if tsconfig.json is not configured.
+        { filename, code: "let foo = []; foo.at(-1)" },
+        { filename, code: "let foo = Array(); foo.at(-1)" },
+        {
+            filename,
+            code: "function f<T extends any[]>(a: T) { a.at(-1) }",
+        },
+        {
+            filename,
+            code:
+                "function f<T extends string[] | number[]>(a: T) { a.at(-1) }",
+        },
+    ],
+    invalid: [
+        {
+            filename,
+            code: "[1, 2, 3].at(-1)",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+        },
+        {
+            filename,
+            code: "'123'.at(-1)",
+            errors: ["ES2022 'String.prototype.at' method is forbidden."],
+        },
+        {
+            filename,
+            code: "let foo = []; foo.at(-1)",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: true } },
+        },
+        {
+            filename,
+            code: "let foo = Array(); foo.at(-1)",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: true } },
+        },
+        {
+            filename,
+            code: "function f<T extends any[]>(a: T) { a.at(-1) }",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: true } },
+        },
+        {
+            filename,
+            code:
+                "function f<T extends string[] | number[]>(a: T) { a.at(-1) }",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: true } },
+        },
+        {
+            filename,
+            code: "foo.at(-1)",
+            errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            settings: { es: { aggressive: true } },
+        },
+    ],
+})
+
+new RuleTester({ parser, parserOptions: { tsconfigRootDir, project } }).run(
+    `${ruleId} TS Full Type Information`,
+    rule,
+    {
+        valid: [
+            { filename, code: "at(-1)" },
+            { filename, code: "foo.reverse()" },
+            { filename, code: "foo.at(-1)" },
+            { filename, code: "let foo = {}; foo.at(-1)" },
+            {
+                filename,
+                code: "at(-1)",
+                settings: { es: { aggressive: true } },
+            },
+            {
+                filename,
+                code: "foo.reverse()",
+                settings: { es: { aggressive: true } },
+            },
+        ],
+        invalid: [
+            {
+                filename,
+                code: "[1, 2, 3].at(-1)",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "'123'.at(-1)",
+                errors: ["ES2022 'String.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "let foo = []; foo.at(-1)",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "let foo = Array(); foo.at(-1)",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "function f<T extends any[]>(a: T) { a.at(-1) }",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "function f<T extends readonly any[]>(a: T) { a.at(-1) }",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code:
+                    "function f<T extends string[] | number[]>(a: T) { a.at(-1) }",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "foo.at(-1)",
+                errors: ["ES2022 'Array.prototype.at' method is forbidden."],
+                settings: { es: { aggressive: true } },
+            },
+            {
+                filename,
+                code: "let foo = 'str'; foo.at(-1)",
+                errors: ["ES2022 'String.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "let foo = String(42); foo.at(-1)",
+                errors: ["ES2022 'String.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "function f<T extends string>(a: T) { a.at(-1) }",
+                errors: ["ES2022 'String.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "function f<T extends 'a' | 'b'>(a: T) { a.at(-1) }",
+                errors: ["ES2022 'String.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code:
+                    "function f<T extends 'a' | 'b' | 'c'>(a: T) { a.at(-1) }",
+                errors: ["ES2022 'String.prototype.at' method is forbidden."],
+            },
+            {
+                filename,
+                code: "let foo = new Int8Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Int8Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Int8Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Int8Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Uint8Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Uint8Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Uint8Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Uint8Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Uint8ClampedArray(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Uint8ClampedArray.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code:
+                    "function f<T extends Uint8ClampedArray>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Uint8ClampedArray.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Int16Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Int16Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Int16Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Int16Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Uint16Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Uint16Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Uint16Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Uint16Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Int32Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Int32Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Int32Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Int32Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Uint32Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Uint32Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Uint32Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Uint32Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Float32Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Float32Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Float32Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Float32Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new Float64Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'Float64Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends Float64Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'Float64Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new BigInt64Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'BigInt64Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends BigInt64Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'BigInt64Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "let foo = new BigUint64Array(42); foo.at(-1)",
+                errors: [
+                    "ES2022 'BigUint64Array.prototype.at' method is forbidden.",
+                ],
+            },
+            {
+                filename,
+                code: "function f<T extends BigUint64Array>(a: T) { a.at(-1) }",
+                errors: [
+                    "ES2022 'BigUint64Array.prototype.at' method is forbidden.",
+                ],
+            },
+        ],
+    },
+)


### PR DESCRIPTION
This PR adds `es/no-array-string-prototype-at` rule.
`es/no-array-string-prototype-at` rule reports ES2022 [`{Array,String,TypedArray}.prototype.at` methods](https://github.com/tc39/proposal-relative-indexing-method) as errors.

close #76