### PR TITLE
feat: support ESLint 8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Packages
         run: npm install
       - name: Lint
@@ -28,37 +28,43 @@ jobs:
 
     strategy:
       matrix:
-        eslint: [7]
-        node: [14]
+        eslint: [8]
+        node: [16]
         os: [ubuntu-latest]
         include:
           # On other platforms
-          - eslint: 7
-            node: 14
+          - eslint: 8
+            node: 16
             os: windows-latest
-          - eslint: 7
-            node: 14
+          - eslint: 8
+            node: 16
             os: macos-latest
           # On old Node.js versions
-          - eslint: 7
+          - eslint: 8
+            node: 14
+            os: ubuntu-latest
+          - eslint: 8
             node: 12
             os: ubuntu-latest
           - eslint: 7
             node: 10
             os: ubuntu-latest
           # On old ESLint versions
+          - eslint: 7
+            node: 16
+            os: ubuntu-latest
           - eslint: 6
-            node: 14
+            node: 16
             os: ubuntu-latest
           - eslint: 5
-            node: 14
+            node: 16
             os: ubuntu-latest
           - eslint: 4
-            node: 14
+            node: 16
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
-          - eslint: 4
-            node: "8.10"
+          - eslint: 4.19.1
+            node: 10
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
@@ -66,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - name: Install Packages

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "ESLint plugin about ECMAScript syntactic features.",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^10.0.0 || ^12.0.0 || >=14.0.0"
   },
   "main": "lib/index.js",
   "files": [
@@ -13,18 +13,18 @@
     "eslint": ">=4.19.1"
   },
   "dependencies": {
-    "eslint-utils": "^2.0.0",
+    "eslint-utils": "^3.0.0",
     "regexpp": "^3.0.0"
   },
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
-    "@typescript-eslint/parser": "^4.8.2",
+    "@typescript-eslint/parser": "^5.0.0",
     "@vuepress/plugin-pwa": "^1.2.0",
     "acorn": "^7.1.0",
     "codecov": "^3.8.1",
-    "eslint": "^7.10.0",
-    "eslint4b": "^7.10.0",
-    "espree": "^7.0.0",
+    "eslint": "^8.0.0",
+    "eslint4b": "^7.32.0",
+    "espree": "^9.0.0",
     "globals": "^12.0.0",
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
@@ -32,7 +32,7 @@
     "opener": "^1.5.1",
     "rimraf": "^3.0.0",
     "semver": "^6.3.0",
-    "typescript": "^4.1.2",
+    "typescript": "^4.4.3",
     "vue-eslint-editor": "^1.1.0",
     "vuepress": "^1.2.0"
   },

--- a/scripts/update-docs-rules.js
+++ b/scripts/update-docs-rules.js
@@ -6,7 +6,7 @@
 
 const fs = require("fs")
 const path = require("path")
-const { CLIEngine } = require("eslint")
+const { ESLint } = require("eslint")
 const { rules } = require("./rules")
 const { version } = require("../package.json")
 
@@ -15,8 +15,8 @@ const configRoot = path.resolve(__dirname, "../lib/configs/")
 const configs = fs.readdirSync(configRoot).map(filename => {
     const id = `plugin:es/${path.basename(filename, ".js")}`
     const configFile = path.join(configRoot, filename)
-    const engine = new CLIEngine({ configFile, useEslintrc: false })
-    const config = engine.getConfigForFile("a.js")
+    const engine = new ESLint({ configFile, useEslintrc: false })
+    const config = engine.calculateConfigForFile("a.js")
     const ruleIds = new Set(Object.keys(config.rules))
     return { id, ruleIds }
 })

--- a/scripts/update-lib-configs.js
+++ b/scripts/update-lib-configs.js
@@ -6,7 +6,7 @@
 
 const fs = require("fs")
 const path = require("path")
-const { CLIEngine } = require("eslint")
+const { ESLint } = require("eslint")
 const { categories } = require("./rules")
 const Root = path.resolve(__dirname, "../lib/configs")
 
@@ -59,6 +59,4 @@ for (const { experimental, revision, rules } of Object.values(categories)) {
     }
 }
 
-CLIEngine.outputFixes(
-    new CLIEngine({ fix: true }).executeOnFiles(["lib/configs"]),
-)
+ESLint.outputFixes(new ESLint({ fix: true }).lintFiles(["lib/configs"]))

--- a/scripts/update-lib-index.js
+++ b/scripts/update-lib-index.js
@@ -6,7 +6,7 @@
 
 const fs = require("fs")
 const path = require("path")
-const { CLIEngine } = require("eslint")
+const { ESLint } = require("eslint")
 const { rules } = require("./rules")
 const collator = new Intl.Collator("en", { numeric: true })
 
@@ -54,6 +54,4 @@ module.exports = {
 `,
 )
 
-CLIEngine.outputFixes(
-    new CLIEngine({ fix: true }).executeOnFiles(["lib/index.js"]),
-)
+ESLint.outputFixes(new ESLint({ fix: true }).lintFiles(["lib/index.js"]))


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [ ] [`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin) (https://github.com/mysticatea/eslint-plugin/issues/31)
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/29
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/32
  - [ ] Release
- [x] [`@typescript-eslint/parser`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser) (https://github.com/typescript-eslint/typescript-eslint/issues/3738)
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3737
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3767
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3768
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3800
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3806
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3808
  - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3809
  - [x] [`v5.0.0`](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0)
- [ ] [`eslint4b`](https://github.com/mysticatea/eslint4b) (https://github.com/mysticatea/eslint4b/issues/13)
  - [ ] https://github.com/mysticatea/eslint4b/pull/14
  - [ ] Release

---

BREAKING CHANGE: Requires Node@^10.0.0 || ^12.0.0 || >=14.0.0

Closes #75