### PR TITLE
doc: enhanced code examples

### DIFF
--- a/docs/rules/no-template-literals.md
+++ b/docs/rules/no-template-literals.md
@@ -22,7 +22,7 @@ const a3 = bar+`foo`
 const a1 = &quot;foo&quot;
 const a2 = &quot;foo&quot;+bar+&quot;baz&quot;
 const a3 = bar+&quot;foo&quot;
-const a4 = bar+&apos;foo&apos;
+const a4 = bar+'foo'
 " />
 
 ## 📚 References

--- a/docs/rules/no-template-literals.md
+++ b/docs/rules/no-template-literals.md
@@ -13,7 +13,7 @@ This rule reports ES2015 template literals as errors.
 <eslint-playground type="bad" code="/*eslint es/no-template-literals: error */
 const a1 = `foo`
 const a2 = `foo${bar}baz`
-const a3 = tag`foo`
+const a3 = bar+`foo`
 " />
 
 👌 Examples of **correct** code for this rule:
@@ -21,6 +21,8 @@ const a3 = tag`foo`
 <eslint-playground type="good" code="/*eslint es/no-template-literals: error */
 const a1 = &quot;foo&quot;
 const a2 = &quot;foo&quot;+bar+&quot;baz&quot;
+const a3 = bar+&quot;foo&quot;
+const a4 = bar+&apos;foo&apos;
 " />
 
 ## 📚 References


### PR DESCRIPTION
The third example was syntactically incorrect so I added a plus sign and added more examples for correct code regarding other ways to format string literals (hopefully the same way the testing function reveals it).